### PR TITLE
Add Qwen3-[4B,8B,32B]

### DIFF
--- a/bonsai/models/qwen3/modeling.py
+++ b/bonsai/models/qwen3/modeling.py
@@ -89,6 +89,7 @@ class ModelCfg:
     rope_scaling_factor: int
     local_rope_theta: float
     norm_eps: float
+    tie_word_embeddings: bool
     shd_cfg: ShardingCfg = ShardingCfg.default()
 
     @classmethod
@@ -105,6 +106,7 @@ class ModelCfg:
             rope_theta=1_000_000,
             rope_scaling_factor=8.0,
             local_rope_theta=1e4,
+            tie_word_embeddings=True,
         )
 
     @classmethod
@@ -121,6 +123,41 @@ class ModelCfg:
             rope_theta=1_000_000,
             rope_scaling_factor=8.0,
             local_rope_theta=1e4,
+            tie_word_embeddings=True,
+        )
+
+    @classmethod
+    def qwen3_4b(cls):  # qwen3-4B
+        return cls(
+            num_layers=36,
+            vocab_size=151936,
+            emb_dim=2560,
+            hidden_dim=9728,
+            num_heads=32,
+            head_dim=128,
+            num_kv_heads=8,
+            norm_eps=1e-06,
+            rope_theta=1_000_000,
+            rope_scaling_factor=8.0,
+            local_rope_theta=1e4,
+            tie_word_embeddings=True,
+        )
+
+    @classmethod
+    def qwen3_8b(cls):  # qwen3-8B
+        return cls(
+            num_layers=36,
+            vocab_size=151936,
+            emb_dim=4096,
+            hidden_dim=12288,
+            num_heads=32,
+            head_dim=128,
+            num_kv_heads=8,
+            norm_eps=1e-06,
+            rope_theta=1_000_000,
+            rope_scaling_factor=8.0,
+            local_rope_theta=1e4,
+            tie_word_embeddings=False,
         )
 
     @classmethod
@@ -137,6 +174,24 @@ class ModelCfg:
             rope_theta=1_000_000,
             rope_scaling_factor=8.0,
             local_rope_theta=1e4,
+            tie_word_embeddings=False,
+        )
+
+    @classmethod
+    def qwen3_32b(cls):  # qwen3-32B
+        return cls(
+            num_layers=64,
+            vocab_size=151936,
+            emb_dim=5120,
+            hidden_dim=25600,
+            num_heads=64,
+            head_dim=128,
+            num_kv_heads=8,
+            norm_eps=1e-06,
+            rope_theta=1_000_000,
+            rope_scaling_factor=8.0,
+            local_rope_theta=1e4,
+            tie_word_embeddings=False,
         )
 
 

--- a/bonsai/models/qwen3/params.py
+++ b/bonsai/models/qwen3/params.py
@@ -138,6 +138,8 @@ def create_model_from_safe_tensors(
         jax_key, transform = _torch_key_to_jax_key(_get_key_and_transform_mapping(cfg), k)
         jax_keys = [_stoi(s) for s in jax_key.split(".")]
         _assign_weights(jax_keys, v, state_dict, k, transform)
+    if cfg.tie_word_embeddings:
+        state_dict['lm_head']['w'] = state_dict['embedder']['input_emb'].T
     if mesh is not None:
         sharding = nnx.get_named_sharding(abs_state, mesh).to_pure_dict()
         state_dict = jax.device_put(state_dict, sharding)

--- a/bonsai/models/qwen3/tests/run_model.py
+++ b/bonsai/models/qwen3/tests/run_model.py
@@ -57,7 +57,11 @@ def run_model(MODEL_CP_PATH=None):
     config = modeling.ModelCfg.qwen3_0_6b()
     model = params.create_model_from_safe_tensors(MODEL_CP_PATH, config)
     cache = modeling.init_cache(
-        num_layers=28, batch_size=batch_size, cache_size=cache_size, num_kv_heads=8, head_dim=128
+        num_layers=config.num_layers,
+        batch_size=batch_size,
+        cache_size=cache_size,
+        num_kv_heads=config.num_kv_heads,
+        head_dim=config.head_dim
     )
     graphdef, state = nnx.split((model, cache))
     state = jax.tree.leaves(state)  # Better perf from flattened jax state due to no pytree trasversals.


### PR DESCRIPTION
- This PR adds Qwen3-4B/8B/32B
- I add config argument `tie_word_embeddings` because checkpoints does not always have `lm_head` weight if `tie_word_embeddings=True`
- I fix some hard coded configuration for testing