### PR TITLE
VGG testing and classifier head corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,8 @@ We welcome contribution of new models that may be beneficial for the JAX communi
     │       ├── tests
     │       │   ├── __init__.py
     │       │   ├── model_validation_colab.ipynb
-    │       │   └── run_model.py
+    │       │   ├── run_model.py
+    │       │   └── test_outputs.py
     │       ├── README.md
     │       ├── modeling.py
     │       └── params.py
@@ -179,5 +180,6 @@ We welcome contribution of new models that may be beneficial for the JAX communi
     * `tests/`: Make sure the contributed model has reasonable performance and correct quality.
       * Run [JAX profiling](https://docs.jax.dev/en/latest/profiling.html#viewing-the-trace) (i.e. `xprof --port 8791 /tmp/profile-data`) to make sure the model code fully utilizes benefits of JAX's [jit capabilities](https://docs.jax.dev/en/latest/jit-compilation.html).
       * Add a validation colab ([SAM2 example](bonsai/models/sam2/tests/SAM2_image_predictor_example.ipynb)) to make sure the model functions properly.
+      * Add a few tests to `test_outputs.py` to confirm that model forward passes are consistent with a reference implementation. 
    
    See an example model directory in [Qwen3](bonsai/models/qwen3).

--- a/bonsai/models/vgg19/params.py
+++ b/bonsai/models/vgg19/params.py
@@ -79,12 +79,12 @@ def _get_key_and_transform_mapping():
         r"^layers/vgg_backbone/layers/conv2d_15/vars/0$": ("conv_block4.conv_layers.3.kernel", None),
         r"^layers/vgg_backbone/layers/conv2d_15/vars/1$": ("conv_block4.conv_layers.3.bias", None),
         # Classifier
-        r"^layers/sequential/layers/conv2d/vars/0$": ("classifier.layers.0.kernel", (None, (-1, 4096))),
+        r"^layers/sequential/layers/conv2d/vars/0$": ("classifier.layers.0.kernel", None),
         r"^layers/sequential/layers/conv2d/vars/1$": ("classifier.layers.0.bias", None),
-        r"^layers/sequential/layers/conv2d_1/vars/0$": ("classifier.layers.2.kernel", (None, (4096, 4096))),
-        r"^layers/sequential/layers/conv2d_1/vars/1$": ("classifier.layers.2.bias", None),
-        r"^layers/sequential/layers/dense/vars/0$": ("classifier.layers.4.kernel", None),
-        r"^layers/sequential/layers/dense/vars/1$": ("classifier.layers.4.bias", None),
+        r"^layers/sequential/layers/conv2d_1/vars/0$": ("classifier.layers.1.kernel", None),
+        r"^layers/sequential/layers/conv2d_1/vars/1$": ("classifier.layers.1.bias", None),
+        r"^layers/sequential/layers/dense/vars/0$": ("classifier.layers.3.kernel", None),
+        r"^layers/sequential/layers/dense/vars/1$": ("classifier.layers.3.bias", None),
     }
 
 

--- a/bonsai/models/vgg19/tests/test_outputs.py
+++ b/bonsai/models/vgg19/tests/test_outputs.py
@@ -1,0 +1,74 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import keras_hub
+import numpy as np
+import tensorflow as tf
+from absl.testing import absltest
+from flax import nnx
+from huggingface_hub import snapshot_download
+
+from bonsai.models.vgg19 import modeling
+from bonsai.models.vgg19 import params as params_lib
+
+
+class TestModuleForwardPasses(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.ref_model = keras_hub.models.ImageClassifier.from_preset("vgg_19_imagenet")
+        model_ckpt_path = snapshot_download("keras/vgg_19_imagenet")
+        self.nnx_model = params_lib.create_model_from_h5(model_ckpt_path, modeling.ModelCfg.vgg_19())
+
+    def test_conv(self):
+        ref_model = self.ref_model.backbone
+        nnx_model = self.nnx_model.conv_block0
+
+        image = np.random.uniform(size=(1, 224, 224, 3)).astype(np.float32)
+        jx = jnp.array(image)
+        tx = tf.constant(image)
+
+        ty = ref_model.layers[1](tx)
+        ny = nnx.relu(nnx_model.conv_layers[0](jx))
+
+        np.testing.assert_allclose(ty.numpy(), ny, atol=1e-3)
+
+    def test_conv_block(self):
+        ref_model = self.ref_model.backbone
+        nnx_model = self.nnx_model.conv_block0
+
+        image = np.random.uniform(size=(1, 224, 224, 3)).astype(np.float32)
+        jx = jnp.array(image)
+        tx = tf.constant(image)
+
+        tx = ref_model.layers[1](tx)
+        tx = ref_model.layers[2](tx)
+        ty = ref_model.layers[3](tx)
+        ny = nnx_model(jx)
+
+        np.testing.assert_allclose(ty.numpy(), ny, atol=1e-5)
+
+    def test_full(self):
+        image = np.random.uniform(size=(1, 224, 224, 3)).astype(np.float32)
+        jx = jnp.array(image)
+        tx = tf.constant(image)
+
+        ty = self.ref_model(tx)
+        ny = self.nnx_model(jx)
+
+        np.testing.assert_allclose(ty.numpy(), ny, atol=1e-3)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Updated model classifier and parameter mapping to use Conv instead of Linear where appropriate. 
Added model testing to compare against reference implementation. 
Updated contributing guidelines to include testing. 