### PR TITLE
Making formatting consistent

### DIFF
--- a/bonsai/models/vit/params.py
+++ b/bonsai/models/vit/params.py
@@ -14,8 +14,10 @@
 
 import logging
 import re
+from enum import Enum
 
 import jax
+import jax.numpy as jnp
 import safetensors.flax as safetensors
 from etils import epath
 from flax import nnx
@@ -23,58 +25,87 @@ from flax import nnx
 from bonsai.models.vit import modeling as model_lib
 
 
-def _get_key_and_transform_mapping():
+def _get_key_and_transform_mapping(cfg: model_lib.ModelCfg):
+    head_dim = cfg.hidden_dim // cfg.num_heads
+
+    class Transform(Enum):
+        """Transformations for model parameters"""
+
+        DEFAULT = None
+        BIAS = None
+        LINEAR = ((1, 0), None)
+        SCALE = None
+        ATTN_KQV_BIAS = (None, (cfg.num_heads, head_dim))
+        ATTN_KQV_KERNEL = ((1, 0), (cfg.hidden_dim, cfg.num_heads, head_dim))
+        ATTN_OUT = ((1, 0), (cfg.num_heads, head_dim, cfg.hidden_dim))
+        EMBED = None
+        CONV2D = ((2, 3, 1, 0), None)
+
     # Mapping st_keys -> (nnx_keys, (permute_rule, reshape_rule)).
-    embed_dim, num_heads, head_dim = 768, 12, 64
     return {
-        r"^classifier.bias$": (r"classifier.bias", None),
-        r"^classifier.weight$": (r"classifier.kernel", ((1, 0), None)),
-        r"^vit.embeddings.cls_token$": (r"pos_embeddings.cls_token", None),
-        r"^vit.embeddings.patch_embeddings.projection.bias$": (r"pos_embeddings.projection.bias", None),
-        r"^vit.embeddings.patch_embeddings.projection.weight$": (
-            r"pos_embeddings.projection.kernel",
-            ((2, 3, 1, 0), None),
-        ),
-        r"^vit.embeddings.position_embeddings$": (r"pos_embeddings.pos_embeddings", None),
+        r"^classifier.bias$": (r"classifier.bias", Transform.BIAS),
+        r"^classifier.weight$": (r"classifier.kernel", Transform.LINEAR),
+        r"^vit.embeddings.cls_token$": (r"pos_embeddings.cls_token", Transform.DEFAULT),
+        r"^vit.embeddings.patch_embeddings.projection.bias$": (r"pos_embeddings.projection.bias", Transform.BIAS),
+        r"^vit.embeddings.patch_embeddings.projection.weight$": (r"pos_embeddings.projection.kernel", Transform.CONV2D),
+        r"^vit.embeddings.position_embeddings$": (r"pos_embeddings.pos_embeddings", Transform.EMBED),
         r"^vit.encoder.layer.([0-9]+).attention.attention.key.bias$": (
             r"layers.layers.\1.attention.key.bias",
-            (None, (num_heads, head_dim)),
+            Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.key.weight$": (
             r"layers.layers.\1.attention.key.kernel",
-            ((1, 0), (embed_dim, num_heads, head_dim)),
+            Transform.ATTN_KQV_KERNEL,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.query.bias$": (
             r"layers.layers.\1.attention.query.bias",
-            (None, (num_heads, head_dim)),
+            Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.query.weight$": (
             r"layers.layers.\1.attention.query.kernel",
-            ((1, 0), (embed_dim, num_heads, head_dim)),
+            Transform.ATTN_KQV_KERNEL,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.value.bias$": (
             r"layers.layers.\1.attention.value.bias",
-            (None, (num_heads, head_dim)),
+            Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.value.weight$": (
             r"layers.layers.\1.attention.value.kernel",
-            ((1, 0), (embed_dim, num_heads, head_dim)),
+            Transform.ATTN_KQV_KERNEL,
         ),
-        r"^vit.encoder.layer.([0-9]+).attention.output.dense.bias$": (r"layers.layers.\1.attention.out.bias", None),
+        r"^vit.encoder.layer.([0-9]+).attention.output.dense.bias$": (
+            r"layers.layers.\1.attention.out.bias",
+            Transform.BIAS,
+        ),
         r"^vit.encoder.layer.([0-9]+).attention.output.dense.weight$": (
             r"layers.layers.\1.attention.out.kernel",
-            ((1, 0), (num_heads, head_dim, embed_dim)),
+            Transform.ATTN_OUT,
         ),
-        r"^vit.encoder.layer.([0-9]+).intermediate.dense.bias$": (r"layers.layers.\1.linear1.bias", None),
-        r"^vit.encoder.layer.([0-9]+).intermediate.dense.weight$": (r"layers.layers.\1.linear1.kernel", ((1, 0), None)),
-        r"^vit.encoder.layer.([0-9]+).layernorm_after.bias$": (r"layers.layers.\1.layernorm_after.bias", None),
-        r"^vit.encoder.layer.([0-9]+).layernorm_after.weight$": (r"layers.layers.\1.layernorm_after.scale", None),
-        r"^vit.encoder.layer.([0-9]+).layernorm_before.bias$": (r"layers.layers.\1.layernorm_before.bias", None),
-        r"^vit.encoder.layer.([0-9]+).layernorm_before.weight$": (r"layers.layers.\1.layernorm_before.scale", None),
-        r"^vit.encoder.layer.([0-9]+).output.dense.bias$": (r"layers.layers.\1.linear2.bias", None),
-        r"^vit.encoder.layer.([0-9]+).output.dense.weight$": (r"layers.layers.\1.linear2.kernel", ((1, 0), None)),
-        r"^vit.layernorm.bias$": (r"ln.bias", None),
-        r"^vit.layernorm.weight$": (r"ln.scale", None),
+        r"^vit.encoder.layer.([0-9]+).intermediate.dense.bias$": (r"layers.layers.\1.linear1.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).intermediate.dense.weight$": (
+            r"layers.layers.\1.linear1.kernel",
+            Transform.LINEAR,
+        ),
+        r"^vit.encoder.layer.([0-9]+).layernorm_after.bias$": (
+            r"layers.layers.\1.layernorm_after.bias",
+            Transform.BIAS,
+        ),
+        r"^vit.encoder.layer.([0-9]+).layernorm_after.weight$": (
+            r"layers.layers.\1.layernorm_after.scale",
+            Transform.SCALE,
+        ),
+        r"^vit.encoder.layer.([0-9]+).layernorm_before.bias$": (
+            r"layers.layers.\1.layernorm_before.bias",
+            Transform.BIAS,
+        ),
+        r"^vit.encoder.layer.([0-9]+).layernorm_before.weight$": (
+            r"layers.layers.\1.layernorm_before.scale",
+            Transform.SCALE,
+        ),
+        r"^vit.encoder.layer.([0-9]+).output.dense.bias$": (r"layers.layers.\1.linear2.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).output.dense.weight$": (r"layers.layers.\1.linear2.kernel", Transform.LINEAR),
+        r"^vit.layernorm.bias$": (r"ln.bias", Transform.BIAS),
+        r"^vit.layernorm.weight$": (r"ln.scale", Transform.SCALE),
     }
 
 
@@ -106,7 +137,7 @@ def _assign_weights(keys, tensor, state_dict, st_key, transform):
                 tensor = tensor.reshape(reshape)
         if tensor.shape != state_dict[key].shape:
             raise ValueError(f"Shape mismatch for {st_key}: {tensor.shape} vs {state_dict[key].shape}")
-        state_dict[key] = tensor
+        state_dict[key] = jnp.array(tensor)
     else:
         _assign_weights(rest, tensor, state_dict[key], st_key, transform)
 
@@ -120,7 +151,7 @@ def _stoi(s):
 
 def create_vit_from_pretrained(
     file_dir: str,
-    num_classes: int = 1000,
+    config: model_lib.ModelCfg,
     *,
     mesh: jax.sharding.Mesh | None = None,
 ):
@@ -138,16 +169,25 @@ def create_vit_from_pretrained(
     for f in files:
         tensor_dict |= safetensors.load_file(f)
 
-    vit = model_lib.ViT(num_classes=num_classes, rngs=nnx.Rngs(0))
+    vit = model_lib.ViTClassificationModel(config, rngs=nnx.Rngs(0))
     graph_def, abs_state = nnx.split(vit)
     jax_state = abs_state.to_pure_dict()
 
-    mapping = _get_key_and_transform_mapping()
+    mapping = _get_key_and_transform_mapping(config)
+    conversion_errors = []
     for st_key, tensor in tensor_dict.items():
         jax_key, transform = _st_key_to_jax_key(mapping, st_key)
         if jax_key is None:
             continue
         keys = [_stoi(k) for k in jax_key.split(".")]
-        _assign_weights(keys, tensor, jax_state, st_key, transform)
+        try:
+            _assign_weights(keys, tensor, jax_state, st_key, transform.value)
+        except Exception as e:
+            full_jax_key = ".".join([str(k) for k in keys])
+            conversion_errors.append(f"Failed to assign '{st_key}' to '{full_jax_key}': {type(e).__name__}: {e}")
+
+    if conversion_errors:
+        full_error_log = "\n".join(conversion_errors)
+        raise RuntimeError(f"Encountered {len(conversion_errors)} weight conversion errors. Log:\n{full_error_log}")
 
     return nnx.merge(graph_def, jax_state)

--- a/bonsai/models/vit/tests/run_model.py
+++ b/bonsai/models/vit/tests/run_model.py
@@ -30,7 +30,7 @@ def run_model():
     model_ckpt_path = snapshot_download(model_name)
 
     # Load pretrained model
-    model = params.create_vit_from_pretrained(model_ckpt_path)
+    model = params.create_vit_from_pretrained(model_ckpt_path, model_lib.ModelCfg.vit_p16_224())
     graphdef, state = nnx.split(model)
     flat_state = jax.tree.leaves(state)
 

--- a/bonsai/models/vit/tests/test_outputs_vit.py
+++ b/bonsai/models/vit/tests/test_outputs_vit.py
@@ -6,6 +6,7 @@ from huggingface_hub import snapshot_download
 from transformers import ViTForImageClassification
 
 from bonsai.models.vit import params
+from bonsai.models.vit.modeling import ModelCfg
 
 
 class TestModuleForwardPasses(absltest.TestCase):
@@ -13,7 +14,8 @@ class TestModuleForwardPasses(absltest.TestCase):
         super().setUp()
         model_name = "google/vit-base-patch16-224"
         model_ckpt_path = snapshot_download(model_name)
-        self.bonsai_model = params.create_vit_from_pretrained(model_ckpt_path)
+        self.bonsai_config = ModelCfg.vit_p16_224()
+        self.bonsai_model = params.create_vit_from_pretrained(model_ckpt_path, self.bonsai_config)
         self.baseline_model = ViTForImageClassification.from_pretrained(model_name)
         self.bonsai_model.eval()
         self.baseline_model.eval()


### PR DESCRIPTION
Making formatting consistent across the repo. 
- ModelCfg for each model
- Parameter mapping with Transform Enum
- Configs passed through all Modules
- Exception catching in parameter loading

Will do this in multiple commits. 

**Checklist**

- [x] I have read the **[Contribution Guidelines](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#contributing-a-model)** and used [pre-commit hooks](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#linting-and-type-checking) to format this commit.
- [x] I have added all the necessary **unit tests** for my change. (`run_model.py` for model usage, `test_outputs.py` and/or `model_validation_colab.ipynb` for quality).
- [] **(If using an LLM)** I have carefully reviewed and removed all **superfluous comments** or unneeded, commented-out code. Only necessary and functional code remains.
- [x] I have signed the **[Contributor License Agreement (CLA)](https://cla.developers.google.com/about)**.