### PR TITLE
vit explicit rngs in call

### DIFF
--- a/bonsai/models/vit/params.py
+++ b/bonsai/models/vit/params.py
@@ -16,7 +16,6 @@ import logging
 import re
 from enum import Enum
 
-import jax
 import jax.numpy as jnp
 import safetensors.flax as safetensors
 from etils import epath
@@ -50,60 +49,42 @@ def _get_key_and_transform_mapping(cfg: model_lib.ModelConfig):
         r"^vit.embeddings.patch_embeddings.projection.weight$": (r"pos_embeddings.projection.kernel", Transform.CONV2D),
         r"^vit.embeddings.position_embeddings$": (r"pos_embeddings.pos_embeddings", Transform.EMBED),
         r"^vit.encoder.layer.([0-9]+).attention.attention.key.bias$": (
-            r"layers.layers.\1.attention.key.bias",
+            r"layers.\1.attention.key.bias",
             Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.key.weight$": (
-            r"layers.layers.\1.attention.key.kernel",
+            r"layers.\1.attention.key.kernel",
             Transform.ATTN_KQV_KERNEL,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.query.bias$": (
-            r"layers.layers.\1.attention.query.bias",
+            r"layers.\1.attention.query.bias",
             Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.query.weight$": (
-            r"layers.layers.\1.attention.query.kernel",
+            r"layers.\1.attention.query.kernel",
             Transform.ATTN_KQV_KERNEL,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.value.bias$": (
-            r"layers.layers.\1.attention.value.bias",
+            r"layers.\1.attention.value.bias",
             Transform.ATTN_KQV_BIAS,
         ),
         r"^vit.encoder.layer.([0-9]+).attention.attention.value.weight$": (
-            r"layers.layers.\1.attention.value.kernel",
+            r"layers.\1.attention.value.kernel",
             Transform.ATTN_KQV_KERNEL,
         ),
-        r"^vit.encoder.layer.([0-9]+).attention.output.dense.bias$": (
-            r"layers.layers.\1.attention.out.bias",
-            Transform.BIAS,
-        ),
+        r"^vit.encoder.layer.([0-9]+).attention.output.dense.bias$": (r"layers.\1.attention.out.bias", Transform.BIAS),
         r"^vit.encoder.layer.([0-9]+).attention.output.dense.weight$": (
-            r"layers.layers.\1.attention.out.kernel",
+            r"layers.\1.attention.out.kernel",
             Transform.ATTN_OUT,
         ),
-        r"^vit.encoder.layer.([0-9]+).intermediate.dense.bias$": (r"layers.layers.\1.linear1.bias", Transform.BIAS),
-        r"^vit.encoder.layer.([0-9]+).intermediate.dense.weight$": (
-            r"layers.layers.\1.linear1.kernel",
-            Transform.LINEAR,
-        ),
-        r"^vit.encoder.layer.([0-9]+).layernorm_after.bias$": (
-            r"layers.layers.\1.layernorm_after.bias",
-            Transform.BIAS,
-        ),
-        r"^vit.encoder.layer.([0-9]+).layernorm_after.weight$": (
-            r"layers.layers.\1.layernorm_after.scale",
-            Transform.SCALE,
-        ),
-        r"^vit.encoder.layer.([0-9]+).layernorm_before.bias$": (
-            r"layers.layers.\1.layernorm_before.bias",
-            Transform.BIAS,
-        ),
-        r"^vit.encoder.layer.([0-9]+).layernorm_before.weight$": (
-            r"layers.layers.\1.layernorm_before.scale",
-            Transform.SCALE,
-        ),
-        r"^vit.encoder.layer.([0-9]+).output.dense.bias$": (r"layers.layers.\1.linear2.bias", Transform.BIAS),
-        r"^vit.encoder.layer.([0-9]+).output.dense.weight$": (r"layers.layers.\1.linear2.kernel", Transform.LINEAR),
+        r"^vit.encoder.layer.([0-9]+).intermediate.dense.bias$": (r"layers.\1.linear1.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).intermediate.dense.weight$": (r"layers.\1.linear1.kernel", Transform.LINEAR),
+        r"^vit.encoder.layer.([0-9]+).layernorm_after.bias$": (r"layers.\1.layernorm_after.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).layernorm_after.weight$": (r"layers.\1.layernorm_after.scale", Transform.SCALE),
+        r"^vit.encoder.layer.([0-9]+).layernorm_before.bias$": (r"layers.\1.layernorm_before.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).layernorm_before.weight$": (r"layers.\1.layernorm_before.scale", Transform.SCALE),
+        r"^vit.encoder.layer.([0-9]+).output.dense.bias$": (r"layers.\1.linear2.bias", Transform.BIAS),
+        r"^vit.encoder.layer.([0-9]+).output.dense.weight$": (r"layers.\1.linear2.kernel", Transform.LINEAR),
         r"^vit.layernorm.bias$": (r"ln.bias", Transform.BIAS),
         r"^vit.layernorm.weight$": (r"ln.scale", Transform.SCALE),
     }
@@ -149,12 +130,7 @@ def _stoi(s):
         return s
 
 
-def create_vit_from_pretrained(
-    file_dir: str,
-    config: model_lib.ModelConfig,
-    *,
-    mesh: jax.sharding.Mesh | None = None,
-):
+def create_vit_from_pretrained(file_dir: str, config: model_lib.ModelConfig):
     """
     Load safetensor weights from a file, then convert & merge into a flax.nnx ViT model.
 

--- a/bonsai/models/vit/tests/run_model.py
+++ b/bonsai/models/vit/tests/run_model.py
@@ -39,19 +39,19 @@ def run_model():
     dummy_input = jnp.ones((batch_size, image_size, image_size, channels), dtype=jnp.float32)
 
     # Warmup (triggers compilation)
-    _ = model_lib.forward(graphdef, flat_state, dummy_input).block_until_ready()
+    _ = model_lib.forward(graphdef, flat_state, dummy_input, None).block_until_ready()
 
     # Profile a few steps
     jax.profiler.start_trace("/tmp/profile-vit")
     for _ in range(5):
-        logits = model_lib.forward(graphdef, flat_state, dummy_input)
+        logits = model_lib.forward(graphdef, flat_state, dummy_input, None)
         jax.block_until_ready(logits)
     jax.profiler.stop_trace()
 
     # Timed execution
     t0 = time.perf_counter()
     for _ in range(10):
-        logits = model_lib.forward(graphdef, flat_state, dummy_input).block_until_ready()
+        logits = model_lib.forward(graphdef, flat_state, dummy_input, None).block_until_ready()
     print(f"Step time: {(time.perf_counter() - t0) / 10:.4f} s")
 
     # Show top-1 predicted class

--- a/bonsai/models/vit/tests/test_outputs_vit.py
+++ b/bonsai/models/vit/tests/test_outputs_vit.py
@@ -32,13 +32,13 @@ class TestModuleForwardPasses(absltest.TestCase):
 
         with torch.no_grad():
             ty = torch_emb(tx)
-        jy = nnx_emb(jx)
+        jy = nnx_emb(jx, rngs=None)
 
         torch.testing.assert_close(torch.tensor(jy), ty, rtol=1e-5, atol=1e-5)
 
     def test_first_layer(self):
         torch_layer = self.baseline_model.vit.encoder.layer[0]
-        nnx_layer = self.bonsai_model.layers.layers[0]
+        nnx_layer = self.bonsai_model.layers[0]
 
         hidden_shape = (self.batch_size, 197, 768)
         jx = jax.random.normal(jax.random.key(0), hidden_shape, dtype=jnp.float32)
@@ -46,7 +46,7 @@ class TestModuleForwardPasses(absltest.TestCase):
 
         with torch.no_grad():
             ty = torch_layer(tx)
-        jy = nnx_layer(jx)
+        jy = nnx_layer(jx, rngs=None)
 
         torch.testing.assert_close(torch.tensor(jy), ty, rtol=1e-5, atol=1e-2)
 
@@ -56,7 +56,7 @@ class TestModuleForwardPasses(absltest.TestCase):
 
         with torch.no_grad():
             ty = self.baseline_model(tx).logits
-        jy = self.bonsai_model(jx)
+        jy = self.bonsai_model(jx, rngs=None)
 
         torch.testing.assert_close(torch.tensor(jy), ty, rtol=1e-5, atol=5e-2)
 
@@ -68,7 +68,7 @@ class TestModuleForwardPasses(absltest.TestCase):
 
         with torch.no_grad():
             ty = self.baseline_model(tx, interpolate_pos_encoding=True).logits
-        jy = self.bonsai_model(jx)
+        jy = self.bonsai_model(jx, rngs=None)
 
         torch.testing.assert_close(torch.tensor(jy), ty, rtol=1e-5, atol=1e-1)
 


### PR DESCRIPTION
Updating ViT to use rngs in the call method explicitly
Using nnx.List instead of nnx.Sequential
Updated testing files and params to reflect these changes. 

**Checklist**

- [x] I have read the **[Contribution Guidelines](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#contributing-a-model)** and used [pre-commit hooks](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#linting-and-type-checking) to format this commit.
- [x] I have added all the necessary **unit tests** for my change. (`run_model.py` for model usage, `test_outputs.py` and/or `model_validation_colab.ipynb` for quality).
- [x] **(If using an LLM)** I have carefully reviewed and removed all **superfluous comments** or unneeded, commented-out code. Only necessary and functional code remains.
- [x] I have signed the **[Contributor License Agreement (CLA)](https://cla.developers.google.com/about)**.