### PR TITLE
Removing dinov3 model output class to facilitate jit compilation

### DIFF
--- a/bonsai/models/dinov3/tests/test_outputs_dinov3.py
+++ b/bonsai/models/dinov3/tests/test_outputs_dinov3.py
@@ -97,7 +97,7 @@ class TestForwardPass(absltest.TestCase):
 
         with torch.inference_mode():
             ty = self.baseline_model(tx).last_hidden_state
-        jy = self.bonsai_model(jx).last_hidden_state
+        jy = self.bonsai_model(jx)["last_hidden_state"]
 
         np_y = np.asarray(jax.device_get(jy))
         ty_bonsai = torch.tensor(np_y, dtype=torch.float32)
@@ -113,7 +113,7 @@ class TestForwardPass(absltest.TestCase):
 
         with torch.inference_mode():
             ty = self.baseline_model(tx).pooler_output
-        jy = self.bonsai_model(jx).pooler_output
+        jy = self.bonsai_model(jx)["pooler_output"]
 
         np_y = np.asarray(jax.device_get(jy))
         ty_bonsai = torch.tensor(np_y, dtype=torch.float32)


### PR DESCRIPTION
Resolves #104 

<!--- Please check [issues](https://github.com/jax-ml/bonsai/issues) for any pending model implementations. Consider opening issue if none exists. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->
A small change to `modeling.py` and `test_outputs_dinov3.py` to add jit compilation (removing output dataclass and using a dictionary for output instead), I will update the colab notebook as well.  

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have read the **[Contribution Guidelines](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#contributing-a-model)** and used [pre-commit hooks](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#linting-and-type-checking) to format this commit.
- [x] I have added all the necessary **unit tests** for my change. (`run_model.py` for model usage, `test_outputs.py` and/or `model_validation_colab.ipynb` for quality).
- [x] **(If using an LLM)** I have carefully reviewed and removed all **superfluous comments** or unneeded, commented-out code. Only necessary and functional code remains.
- [x] I have signed the **[Contributor License Agreement (CLA)](https://cla.developers.google.com/about)**.