### PR TITLE
Adding jit support to Qwen3VL, readme fixes

### DIFF
--- a/bonsai/models/qwen3_vl/README.md
+++ b/bonsai/models/qwen3_vl/README.md
@@ -18,7 +18,6 @@ This directory contains a pure JAX implementation of the [Qwen3-VL SOTA Vision L
 | [Qwen3-VL-32B-Thinking](https://huggingface.co/Qwen/Qwen3-VL-32B-Thinking) | **✅ Supported** |
 | [NVIDIA-Cosmos-Reason2-2B](https://huggingface.co/nvidia/Cosmos-Reason2-2B) | **✅ Supported** |
 | [NVIDIA-Cosmos-Reason2-8B](https://huggingface.co/nvidia/Cosmos-Reason2-8B) | **✅ Supported** |
-
 | **MoE Models** | |
 | [Qwen3-VL-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B) | **🟡 Not started** |
 | [Qwen3-VL-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) | **🟡 Not started** |

--- a/bonsai/models/qwen3_vl/modeling.py
+++ b/bonsai/models/qwen3_vl/modeling.py
@@ -1005,6 +1005,7 @@ class Qwen3VLForConditionalGeneration(nnx.Module):
     def __call__(
         self,
         input_ids: Array,
+        cache: Cache,
         pixel_values: Optional[Array] = None,
         image_grid_thw: Optional[GridTHW] = None,
         token_type_ids: Optional[Array] = None,

--- a/bonsai/models/qwen3_vl/tests/run_model.py
+++ b/bonsai/models/qwen3_vl/tests/run_model.py
@@ -117,7 +117,7 @@ def main():
     # Check for vision inputs
     if "pixel_values" in inputs_vision:
         pixel_values = jnp.array(inputs_vision["pixel_values"].numpy())
-        image_grid_thw = jnp.array(inputs_vision["image_grid_thw"].numpy())
+        image_grid_thw = tuple(tuple(row) for row in inputs_vision["image_grid_thw"].long().tolist())
 
         # Create token_type_ids (1 for image tokens, 0 for text)
         # Image token ID is 151655

--- a/bonsai/models/qwen3_vl/tests/test_outputs_qwen3vl.py
+++ b/bonsai/models/qwen3_vl/tests/test_outputs_qwen3vl.py
@@ -382,9 +382,8 @@ class TestVisionComponentsEquivalence(absltest.TestCase):
         flax_visual = self.flax_model.model.visual
 
         # Create grid_thw for a small image: 1 frame, 16x16 grid
-        grid_thw_np = np.array([[1, 16, 16]], dtype=np.int64)
-        grid_thw_pt = torch.tensor(grid_thw_np)
-        grid_thw_jax = jnp.array(grid_thw_np)
+        grid_thw_tuple = ((1, 16, 16),)
+        grid_thw_pt = torch.tensor(grid_thw_tuple, dtype=torch.long)
 
         with torch.inference_mode():
             pt_rope = pt_visual.rot_pos_emb(grid_thw_pt)
@@ -392,7 +391,7 @@ class TestVisionComponentsEquivalence(absltest.TestCase):
             pt_cos = pt_emb.cos().numpy()
             pt_sin = pt_emb.sin().numpy()
 
-        flax_cos, flax_sin = flax_visual._rot_pos_emb(grid_thw_jax)
+        flax_cos, flax_sin = flax_visual._rot_pos_emb(grid_thw_tuple)
 
         np.testing.assert_allclose(np.array(flax_cos), pt_cos, rtol=1e-5, atol=1e-5)
         np.testing.assert_allclose(np.array(flax_sin), pt_sin, rtol=1e-5, atol=1e-5)
@@ -409,9 +408,8 @@ class TestVisionComponentsEquivalence(absltest.TestCase):
         grid_t, grid_h, grid_w = 1, 16, 16
         num_patches = grid_t * grid_h * grid_w  # 256 patches before merge
 
-        grid_thw_np = np.array([[grid_t, grid_h, grid_w]], dtype=np.int64)
-        grid_thw_pt = torch.tensor(grid_thw_np)
-        grid_thw_jax = jnp.array(grid_thw_np)
+        grid_thw_tuple = ((grid_t, grid_h, grid_w),)
+        grid_thw_pt = torch.tensor(grid_thw_tuple, dtype=torch.long)
 
         key = jax.random.PRNGKey(42)
         jx = jax.random.normal(key, (num_patches, per_patch_size), dtype=jnp.float32)
@@ -428,7 +426,7 @@ class TestVisionComponentsEquivalence(absltest.TestCase):
             else:
                 pt_out = pt_result[0].numpy()
 
-        flax_out, flax_deepstack = flax_visual(jx, grid_thw_jax)
+        flax_out, flax_deepstack = flax_visual(jx, grid_thw_tuple)
         flax_out = np.array(flax_out)
 
         # After spatial merge (2x2), 256 patches become 64
@@ -629,11 +627,11 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
         """Check position embedding interpolation output matches."""
         inputs = self._create_dummy_image_input()
         grid_thw_pt = inputs["image_grid_thw"]
-        grid_thw_jax = jnp.array(grid_thw_pt.numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in grid_thw_pt.long().tolist())
 
         with torch.inference_mode():
             pt_pos = self.pt_model.model.visual.fast_pos_embed_interpolate(grid_thw_pt).numpy()
-        flax_pos = np.array(self.flax_model.model.visual._fast_pos_embed_interpolate(grid_thw_jax))
+        flax_pos = np.array(self.flax_model.model.visual._fast_pos_embed_interpolate(grid_thw_tuple))
 
         np.testing.assert_allclose(flax_pos, pt_pos, rtol=1e-5, atol=3e-5)
 
@@ -641,7 +639,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
         """Check RoPE embedding output matches."""
         inputs = self._create_dummy_image_input()
         grid_thw_pt = inputs["image_grid_thw"]
-        grid_thw_jax = jnp.array(grid_thw_pt.numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in grid_thw_pt.long().tolist())
 
         with torch.inference_mode():
             pt_rope = self.pt_model.model.visual.rot_pos_emb(grid_thw_pt)
@@ -649,7 +647,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
             pt_cos = pt_emb.cos().numpy()
             pt_sin = pt_emb.sin().numpy()
 
-        flax_cos, flax_sin = self.flax_model.model.visual._rot_pos_emb(grid_thw_jax)
+        flax_cos, flax_sin = self.flax_model.model.visual._rot_pos_emb(grid_thw_tuple)
 
         np.testing.assert_allclose(np.array(flax_cos), pt_cos, rtol=1e-6, atol=2e-5)
         np.testing.assert_allclose(np.array(flax_sin), pt_sin, rtol=1e-6, atol=2e-5)
@@ -660,7 +658,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
         pixel_values_pt = inputs["pixel_values"]
         grid_thw_pt = inputs["image_grid_thw"]
         pixel_values_jax = jnp.array(pixel_values_pt.numpy())
-        grid_thw_jax = jnp.array(grid_thw_pt.numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in grid_thw_pt.long().tolist())
 
         # Get patch + pos embeddings
         with torch.inference_mode():
@@ -669,7 +667,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
             pt_hidden = (pt_patches + pt_pos).numpy()
 
         flax_patches = self.flax_model.model.visual.patch_embed(pixel_values_jax)
-        flax_pos = self.flax_model.model.visual._fast_pos_embed_interpolate(grid_thw_jax)
+        flax_pos = self.flax_model.model.visual._fast_pos_embed_interpolate(grid_thw_tuple)
         flax_hidden = np.array(flax_patches + flax_pos)
 
         np.testing.assert_allclose(flax_hidden, pt_hidden, rtol=1e-5, atol=1e-5)
@@ -680,7 +678,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
         pixel_values_pt = inputs["pixel_values"]
         grid_thw_pt = inputs["image_grid_thw"]
         pixel_values_jax = jnp.array(pixel_values_pt.numpy())
-        grid_thw_jax = jnp.array(grid_thw_pt.numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in grid_thw_pt.long().tolist())
 
         with torch.inference_mode():
             pt_result = self.pt_model.model.visual(pixel_values_pt, grid_thw_pt)
@@ -691,7 +689,7 @@ class TestVisionEncoderPretrained(PretrainedModelMixin, absltest.TestCase):
                 pt_out = self.pt_model.model.visual.merger(pt_hidden).numpy()
             else:
                 pt_out = pt_result[0].numpy()
-        flax_out, _ = self.flax_model.model.visual(pixel_values_jax, grid_thw_jax)
+        flax_out, _ = self.flax_model.model.visual(pixel_values_jax, grid_thw_tuple)
 
         self.assertEqual(
             np.array(flax_out).shape,
@@ -730,7 +728,7 @@ class TestVisionTextGeneration(PretrainedModelMixin, absltest.TestCase):
         input_ids_pt = inputs["input_ids"]
 
         pixel_values_jax = jnp.array(pixel_values_pt.numpy())
-        grid_thw_jax = jnp.array(grid_thw_pt.numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in grid_thw_pt.long().tolist())
         input_ids_jax = jnp.array(input_ids_pt.numpy())
 
         # Create token_type_ids: 1 for image tokens, 0 for text
@@ -751,7 +749,7 @@ class TestVisionTextGeneration(PretrainedModelMixin, absltest.TestCase):
         cache = model_lib.init_cache(self.flax_config, batch, seq_len, 20)
 
         flax_logits, cache = model_lib.forward_vision(
-            self.flax_model, cache, input_ids_jax, pixel_values_jax, grid_thw_jax, token_type_ids_jax
+            self.flax_model, cache, input_ids_jax, pixel_values_jax, grid_thw_tuple, token_type_ids_jax
         )
 
         # Vision+text forward has larger tolerance due to accumulated numerical diffs
@@ -785,7 +783,7 @@ class TestVisionTextGeneration(PretrainedModelMixin, absltest.TestCase):
         )
 
         pixel_values_jax = jnp.array(inputs["pixel_values"].numpy())
-        grid_thw_jax = jnp.array(inputs["image_grid_thw"].numpy())
+        grid_thw_tuple = tuple(tuple(row) for row in inputs["image_grid_thw"].long().tolist())
         input_ids_jax = jnp.array(inputs["input_ids"].numpy())
 
         # Create token_type_ids: 1 for image tokens, 0 for text
@@ -797,7 +795,7 @@ class TestVisionTextGeneration(PretrainedModelMixin, absltest.TestCase):
 
         # Prefill with vision
         logits, cache = model_lib.forward_vision(
-            self.flax_model, cache, input_ids_jax, pixel_values_jax, grid_thw_jax, token_type_ids_jax
+            self.flax_model, cache, input_ids_jax, pixel_values_jax, grid_thw_tuple, token_type_ids_jax
         )
 
         # Verify cache position

--- a/bonsai/models/qwen3_vl/tests/test_sharding_qwen3vl.py
+++ b/bonsai/models/qwen3_vl/tests/test_sharding_qwen3vl.py
@@ -6,7 +6,7 @@ import unittest
 
 from flax import nnx
 from jax._src.mesh import AxisType
-from jax.sharding import PartitionSpec as P
+from jax.sharding import NamedSharding, PartitionSpec as P
 
 from bonsai.models.qwen3_vl import modeling
 
@@ -45,62 +45,49 @@ def get_test_config(use_fsdp=False, use_tp=False):
     )
 
 
-@unittest.skipIf(jax.device_count() < 4, "Atleast 4 devices required")
+@unittest.skipIf(jax.device_count() < 8, "At least 8 devices required")
 class TestSharding(absltest.TestCase):
-    """Test sharding with simulated 8-device mesh."""
+    """Test sharding with simulated 8-device mesh (FSDP=4, TP=2)."""
 
     @classmethod
     def setUpClass(cls):
-        print(f"JAX devices: {jax.devices()}")
-        print(f"Device count: {len(jax.devices())}")
-        assert len(jax.devices()) == 8, f"Expected 8 simulated devices, got {len(jax.devices())}"
+        super().setUpClass()
+        cls.mesh = jax.make_mesh((4, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
+        jax.set_mesh(cls.mesh)
+        cls.cfg_unsharded = get_test_config(use_fsdp=False, use_tp=False)
+        cls.cfg_sharded = get_test_config(use_fsdp=True, use_tp=True)
 
     def test_sharding_config_creation(self):
         """Test that sharding configs are created correctly."""
-        # No sharding
         cfg_unsharded = modeling.Qwen3VLConfig.qwen3vl_2b()
         self.assertEqual(cfg_unsharded.text_config.shd_cfg.q_weight, P(None, None))
 
-        # With sharding
         cfg_sharded = modeling.Qwen3VLConfig.qwen3vl_2b(use_fsdp=True, use_tp=True)
         self.assertEqual(cfg_sharded.text_config.shd_cfg.q_weight, P("fsdp", "tp"))
         self.assertEqual(cfg_sharded.vision_config.shd_cfg.attn_qkv_kernel, P("fsdp", "tp"))
 
     def test_text_mlp_sharded_vs_unsharded(self):
         """Test text MLP output is numerically equivalent with/without sharding."""
-        # Setup mesh for sharded test
-        mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
-
-        # Create unsharded model and input
-        cfg_unsharded = get_test_config(use_fsdp=False, use_tp=False)
         rngs = nnx.Rngs(42)
-        mlp_unsharded = modeling.Qwen3VLMLP(cfg_unsharded.text_config, rngs=rngs)
+        mlp_unsharded = modeling.Qwen3VLMLP(self.cfg_unsharded.text_config, rngs=rngs)
 
-        # Capture weights from unsharded model using [...] indexing
         gate_kernel = np.array(mlp_unsharded.gate_proj.kernel[...])
         up_kernel = np.array(mlp_unsharded.up_proj.kernel[...])
         down_kernel = np.array(mlp_unsharded.down_proj.kernel[...])
 
-        # Use batch=2 so it's divisible by fsdp=2
-        x = jnp.ones((2, 8, 128), dtype=jnp.float32)  # (batch, seq, hidden)
+        x = jnp.ones((4, 8, 128), dtype=jnp.float32)
         out_unsharded = mlp_unsharded(x)
 
-        # Create sharded model with same weights
-        jax.set_mesh(mesh)
-        cfg_sharded = get_test_config(use_fsdp=True, use_tp=True)
         rngs = nnx.Rngs(42)
-        mlp_sharded = modeling.Qwen3VLMLP(cfg_sharded.text_config, rngs=rngs)
+        mlp_sharded = modeling.Qwen3VLMLP(self.cfg_sharded.text_config, rngs=rngs)
 
-        # Copy weights to sharded model using [...] indexing
         mlp_sharded.gate_proj.kernel[...] = jnp.array(gate_kernel)
         mlp_sharded.up_proj.kernel[...] = jnp.array(up_kernel)
         mlp_sharded.down_proj.kernel[...] = jnp.array(down_kernel)
 
-        # Recreate input inside mesh context
-        x_sharded = jnp.ones((2, 8, 128), dtype=jnp.float32)
+        x_sharded = jnp.ones((4, 8, 128), dtype=jnp.float32)
         out_sharded = mlp_sharded(x_sharded)
 
-        # Numerical comparison
         np.testing.assert_allclose(
             np.array(out_unsharded),
             np.array(out_sharded),
@@ -108,40 +95,28 @@ class TestSharding(absltest.TestCase):
             atol=1e-5,
             err_msg="Sharded MLP output differs from unsharded",
         )
-        print("Text MLP: sharded vs unsharded numerical match ✓")
-
-        # Reset mesh
-        jax.set_mesh(jax.make_mesh((1,), ("dummy",), axis_types=(AxisType.Explicit,)))
 
     def test_vision_mlp_sharded_vs_unsharded(self):
         """Test vision MLP output is numerically equivalent with/without sharding."""
-        mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
-
-        # Create unsharded model
-        cfg_unsharded = get_test_config(use_fsdp=False, use_tp=False)
         rngs = nnx.Rngs(42)
-        mlp_unsharded = modeling.Qwen3VLVisionMLP(cfg_unsharded.vision_config, rngs=rngs)
+        mlp_unsharded = modeling.Qwen3VLVisionMLP(self.cfg_unsharded.vision_config, rngs=rngs)
 
         fc1_kernel = np.array(mlp_unsharded.linear_fc1.kernel[...])
         fc2_kernel = np.array(mlp_unsharded.linear_fc2.kernel[...])
         fc1_bias = np.array(mlp_unsharded.linear_fc1.bias[...])
         fc2_bias = np.array(mlp_unsharded.linear_fc2.bias[...])
 
-        x = jnp.ones((16, 64), dtype=jnp.float32)  # (seq, hidden)
+        x = jnp.ones((16, 64), dtype=jnp.float32)
         out_unsharded = mlp_unsharded(x)
 
-        # Create sharded model
-        jax.set_mesh(mesh)
-        cfg_sharded = get_test_config(use_fsdp=True, use_tp=True)
         rngs = nnx.Rngs(42)
-        mlp_sharded = modeling.Qwen3VLVisionMLP(cfg_sharded.vision_config, rngs=rngs)
+        mlp_sharded = modeling.Qwen3VLVisionMLP(self.cfg_sharded.vision_config, rngs=rngs)
 
         mlp_sharded.linear_fc1.kernel[...] = jnp.array(fc1_kernel)
         mlp_sharded.linear_fc2.kernel[...] = jnp.array(fc2_kernel)
         mlp_sharded.linear_fc1.bias[...] = jnp.array(fc1_bias)
         mlp_sharded.linear_fc2.bias[...] = jnp.array(fc2_bias)
 
-        # Recreate input inside mesh context
         x_sharded = jnp.ones((16, 64), dtype=jnp.float32)
         out_sharded = mlp_sharded(x_sharded)
 
@@ -152,104 +127,65 @@ class TestSharding(absltest.TestCase):
             atol=1e-5,
             err_msg="Sharded Vision MLP output differs from unsharded",
         )
-        print("Vision MLP: sharded vs unsharded numerical match ✓")
-
-        jax.set_mesh(jax.make_mesh((1,), ("dummy",), axis_types=(AxisType.Explicit,)))
 
     def test_full_model_creation_with_sharding(self):
         """Test full model can be created with sharding enabled."""
-        mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
-        jax.set_mesh(mesh)
-
-        cfg = get_test_config(use_fsdp=True, use_tp=True)
         rngs = nnx.Rngs(0)
-
-        model = modeling.Qwen3VLForConditionalGeneration(cfg, rngs=rngs)
-
-        # Just verify model was created successfully
+        model = modeling.Qwen3VLForConditionalGeneration(self.cfg_sharded, rngs=rngs)
         self.assertIsNotNone(model)
-        print("Full model created with sharding ✓")
-
-        jax.set_mesh(jax.make_mesh((1,), ("dummy",), axis_types=(AxisType.Explicit,)))
 
     def test_text_model_forward_with_sharding(self):
         """Test text model can run forward pass with sharding enabled."""
-        mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
-        jax.set_mesh(mesh)
-
-        # Create sharded model
-        cfg = get_test_config(use_fsdp=True, use_tp=True)
         rngs = nnx.Rngs(42)
-        text_model = modeling.Qwen3VLTextModel(cfg.text_config, rngs=rngs)
+        text_model = modeling.Qwen3VLTextModel(self.cfg_sharded.text_config, rngs=rngs)
 
-        # Create input - batch=2 divisible by fsdp=2
-        batch, seq_len = 2, 8
+        batch, seq_len = 4, 8
         inputs_embeds = jnp.ones((batch, seq_len, 128), dtype=jnp.float32)
-        cache = modeling.init_cache(cfg, batch_size=batch, token_len=seq_len, generate_steps=4)
+        cache = modeling.init_cache(self.cfg_sharded, batch_size=batch, token_len=seq_len, generate_steps=4)
         positions = jnp.arange(seq_len)[None, :].repeat(batch, axis=0)
-        sin, cos = modeling._generate_rope(positions, cfg.text_config.head_dim, cfg.text_config.rope_theta)
+        sin, cos = modeling._generate_rope(
+            positions, self.cfg_sharded.text_config.head_dim, self.cfg_sharded.text_config.rope_theta
+        )
 
-        # Forward pass should complete without error
         output = text_model(inputs_embeds, cache, sin, cos, mask=None)
-
         self.assertEqual(output.shape, (batch, seq_len, 128))
-        print("Text Model: forward pass with sharding ✓")
-
-        jax.set_mesh(jax.make_mesh((1,), ("dummy",), axis_types=(AxisType.Explicit,)))
 
     def test_vision_attention_sharded_vs_unsharded(self):
         """Test vision attention output is numerically equivalent with/without sharding."""
-        mesh = jax.make_mesh((2, 2), ("fsdp", "tp"), axis_types=(AxisType.Explicit, AxisType.Explicit))
-
-        # Create unsharded model
-        cfg_unsharded = get_test_config(use_fsdp=False, use_tp=False)
         rngs = nnx.Rngs(42)
-        attn_unsharded = modeling.Qwen3VLVisionAttention(cfg_unsharded.vision_config, rngs=rngs)
+        attn_unsharded = modeling.Qwen3VLVisionAttention(self.cfg_unsharded.vision_config, rngs=rngs)
 
-        # Get weights
         graphdef, state = nnx.split(attn_unsharded)
         flat_state = nnx.to_flat_state(state)
         state_arrays = {k: np.array(v[...]) for k, v in zip(flat_state.paths, flat_state.leaves)}
 
-        # Create input - (seq, hidden)
         seq_len = 16
-        hidden_size = cfg_unsharded.vision_config.hidden_size
+        hidden_size = self.cfg_unsharded.vision_config.hidden_size
+        head_dim = self.cfg_unsharded.vision_config.head_dim
         x = jnp.ones((seq_len, hidden_size), dtype=jnp.float32)
 
-        # Create RoPE cos/sin for vision
-        # VisionAttention expects (seq_len, head_dim) for cos/sin
-        head_dim = cfg_unsharded.vision_config.head_dim
-        # Simple RoPE: just use arange positions with full head_dim
-        positions = jnp.arange(seq_len, dtype=jnp.float32)
         theta = 10000.0
+        positions = jnp.arange(seq_len, dtype=jnp.float32)
         freqs = 1.0 / (theta ** (jnp.arange(0, head_dim, 2, dtype=jnp.float32) / head_dim))
-        angles = jnp.outer(positions, freqs)  # (seq_len, head_dim/2)
-        # Repeat to match full head_dim
-        angles = jnp.concatenate([angles, angles], axis=-1)  # (seq_len, head_dim)
+        angles = jnp.concatenate([jnp.outer(positions, freqs)] * 2, axis=-1)
         cos_vals = jnp.cos(angles)
         sin_vals = jnp.sin(angles)
 
         out_unsharded = attn_unsharded(x, (cos_vals, sin_vals))
 
-        # Create sharded model
-        jax.set_mesh(mesh)
-        cfg_sharded = get_test_config(use_fsdp=True, use_tp=True)
         rngs = nnx.Rngs(42)
-        attn_sharded = modeling.Qwen3VLVisionAttention(cfg_sharded.vision_config, rngs=rngs)
+        attn_sharded = modeling.Qwen3VLVisionAttention(self.cfg_sharded.vision_config, rngs=rngs)
 
-        # Copy weights
         sharded_graphdef, sharded_state = nnx.split(attn_sharded)
         sharded_flat_state = nnx.to_flat_state(sharded_state)
         for k, v in zip(sharded_flat_state.paths, sharded_flat_state.leaves):
             if k in state_arrays:
                 v[...] = jnp.array(state_arrays[k])
 
-        # Recreate ALL inputs inside mesh context
         x_sharded = jnp.ones((seq_len, hidden_size), dtype=jnp.float32)
         positions_sharded = jnp.arange(seq_len, dtype=jnp.float32)
         freqs_sharded = 1.0 / (theta ** (jnp.arange(0, head_dim, 2, dtype=jnp.float32) / head_dim))
-        angles_sharded = jnp.outer(positions_sharded, freqs_sharded)
-        angles_sharded = jnp.concatenate([angles_sharded, angles_sharded], axis=-1)
+        angles_sharded = jnp.concatenate([jnp.outer(positions_sharded, freqs_sharded)] * 2, axis=-1)
         cos_sharded = jnp.cos(angles_sharded)
         sin_sharded = jnp.sin(angles_sharded)
 
@@ -262,9 +198,53 @@ class TestSharding(absltest.TestCase):
             atol=1e-4,
             err_msg="Sharded VisionAttention output differs from unsharded",
         )
-        print("Vision Attention: sharded vs unsharded numerical match ✓")
 
-        jax.set_mesh(jax.make_mesh((1,), ("dummy",), axis_types=(AxisType.Explicit,)))
+    def test_full_vision_text_forward(self):
+        """Test full vision+text forward pass with sharding."""
+        rngs = nnx.Rngs(0)
+        fsdp = modeling.ShardMode.FSDP.value
+        model = modeling.Qwen3VLForConditionalGeneration(self.cfg_sharded, rngs=rngs)
+
+        batch_size = 4
+        num_tokens = 128
+        patch_size = self.cfg_sharded.vision_config.patch_size
+        temporal_patch_size = self.cfg_sharded.vision_config.temporal_patch_size
+        in_channels = self.cfg_sharded.vision_config.in_channels
+        spatial_merge_size = self.cfg_sharded.vision_config.spatial_merge_size
+        per_patch_features = in_channels * temporal_patch_size * patch_size * patch_size
+
+        grid_h, grid_w = patch_size, patch_size
+        num_patches_per_image = grid_h * grid_w
+        merged_patches_per_image = num_patches_per_image // (spatial_merge_size**2)
+        total_patches = num_patches_per_image * batch_size
+
+        key = jax.random.key(0)
+        pixel_values = jax.random.uniform(
+            key,
+            (total_patches, per_patch_features),
+            dtype=jnp.float32,
+            minval=-1,
+            maxval=1,
+        )
+
+        n_text = jax.device_put(
+            np.arange(batch_size * num_tokens).reshape(batch_size, -1) % self.cfg_sharded.text_config.vocab_size,
+            device=P(fsdp),
+        )
+
+        token_type_ids = np.zeros((batch_size, num_tokens), dtype=np.int32)
+        token_type_ids[:, 12 : 12 + merged_patches_per_image] = 1
+        n_tti = jax.device_put(token_type_ids, device=P(fsdp))
+
+        image_grid_thw = ((1, grid_h, grid_w),) * batch_size
+        cache = modeling.init_cache(self.cfg_sharded, batch_size, num_tokens, 1, jnp.float32)
+
+        out = model(n_text, cache, pixel_values, image_grid_thw, n_tti)
+
+        self.assertEqual(out.shape, (batch_size, num_tokens, self.cfg_sharded.text_config.vocab_size))
+        self.assertIsInstance(out.sharding, NamedSharding)
+        expected_logit_shd = P(self.cfg_sharded.text_config.shd_cfg.act_btd[0], None, None)
+        self.assertEqual(out.sharding.spec, expected_logit_shd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Adds jit support to Qwen3VL model and fixes some readme files

Based on @vfdev-5 's suggestions, jit support and batched input support added for Qwen3VL model, the tests can be seen here: https://www.kaggle.com/code/prathamshahmldlds/test-bonsai-qwen3-vl (on T4x2 with mesh (1,2)).

@chapman20j and @jenriver do check and merge. 

<!--

Pease read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.
-->

Fixes #161 


**Checklist**
- [x] I have read the **[Contribution Guidelines](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md)** and used [pre-commit hooks](https://github.com/jax-ml/bonsai/blob/main/CONTRIBUTING.md#linting-and-type-checking) to format and squash so that this PR has 1 commit typically.
- [x] I have added all the necessary **unit tests** for my change (`run_model.py`, `test_outputs.py`, and/or `model_validation_colab.ipynb`).
- [x] **(Code Quality)** I have reviewed the code and removed all superfluous comments or LLM-generated boilerplate. Only functional, necessary code remains.
- [x] I have signed the **[Contributor License Agreement (CLA)](https://cla.developers.google.com/about)**.
